### PR TITLE
Refactor helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Logs
+.excludes
 test/

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ _Before I upgraded to the Mac Mini, I was running this on an iMac from **2009** 
 - `$PLEX_PATH`: The folder that contains Plex's Movie and TV Shows library folders
   - If downloading and Plex are both running on the same machine, this is probably just a local folder
   - If you're running Plex on a NAS, mount the drive as a network volume and find the Plex folders
-- `$NOTIFY_SHORTCUT`: The name of a shortcut (Apple Shortcuts) to trigger
+- Notification shortcut (`process-helpers.sh:16`, see below): The name of a shortcut (Apple Shortcuts) to trigger
   - Notifications between Apple devices is surprisingly hard – Apple assumes that if a notification is coming from yourself, that means you've already read it, so it doesn't actually notify
-  - One way to hack around this is using Reminders, here's an [example](https://www.icloud.com/shortcuts/989e685a87d74349864cfcc9c93846c5)
+  - One way to hack around this is using Reminders, here's an [example](https://www.icloud.com/shortcuts/08048084872041e8b2a9804c679f339b)
 
 Everything else is either generated in relation to these things, is passed from Transmission, or returned from FileBot.
 
@@ -86,7 +86,7 @@ PSA: Transmission runs this script as a non-interactive, non-login shell. Depend
 
 I highly recommend finding some very small torrents since you will probably be downloading them over and over and over again when testing this out.
 
-Tip: There is an anime TV show called UFO Baby that is available free on the Internet Archive, hits the right naming conventions for testing, and is about 150MB per episode. I have downloaded the same two episodes dozens of times and have still not watched it.
+Tip: There is an anime TV show called UFO Baby that is available free on the Internet Archive, hits the right naming conventions for testing, and runs about 80–150MB per episode. I have downloaded the same two episodes dozens of times and have still not watched it.
 
 Repeat 3,587,279 times:
 1. Tweak script
@@ -100,6 +100,10 @@ Repeat 3,587,279 times:
 
 For testing things that depend more on how FileBot matches than what comes in from Transmission, I added a `test-filebot.sh` script that includes the bare bones you need to call FileBot from the command line. It's more transparent and a lot quicker than triggering Transmission over and over again.
 
+## Helpers
+
+I've pulled a few functions into a separate file (`process-helpers.sh`) for reusability and consistency. These are sourced in both the main script (`transmission-postprocess.sh:15`) and test script (`test-filebot.sh:9`) so there's parity between testing and the real thing.
+
 ## Edge cases & troubleshooting
 
 The script handles most recent, well-named media you might download. There are a few bugs I've come across and fixed and I expect there will be more.
@@ -107,17 +111,21 @@ The script handles most recent, well-named media you might download. There are a
 ### Destination path:
 - Not surprisingly, if the destination path isn't available, FileBot is gonna have a hard time. The script includes some error handling to hopefully make this transparent.
 - If you're downloading and Plexing from the same machine this likely won't be an issue, but if you are copying files to a NAS then it needs to be mounted when the script runs.
-- I've included a check for the NAS path (:18) and if it isn't a directory, call a script that remounts the NAS drive – you can grab that script from my [wifi-keepalive](https://github.com/madysondesigns/wifi-keepalive) repo.
+- I've included a check for the NAS path (`:19`) and if it isn't a directory, call a script that remounts the NAS drive – you can grab that script from my [wifi-keepalive](https://github.com/madysondesigns/wifi-keepalive) repo.
 
 ### Torrent naming conventions:
 - FileBot relies on the name embedded in the torrent metadata (not the `.torrent` filename itself) and uses that to match media. If a torrent is poorly named I assume the results will be less than spectactular, but most torrents I've come across follow good naming conventions so it's not an issue.
 - Older and more obscure media can be more difficult to match – it seems to be more of an issue with TV shows, and I've found that the `tv` label helps (and I assume it can only be good for performance to narrow down the search).
-- I've included some regex logic (:52-:68) to match common TV naming conventions (e.g. S01E01) but one thing I don't think can be handled automatically is a full series pack – typically these only include the word 'complete' or nothing besides the show name.
+- I've included some regex logic (`process-helpers.sh:31-:47`) to match common TV naming conventions (e.g. S01E01) but one thing I don't think can be handled automatically is a full series pack – typically these only include the word 'complete' or nothing besides the show name.
 
 ### Multi-file torrents:
-- If there are multiple media files in a torrent (e.g. an entire TV season), FileBot will loop through all the files to match and process each. This can also include the `exec` call, depending on the format expressions you use.
--  Some formats (e.g. `fn` or episode numbers) correspond to a file and some (e.g. movie/series name) correspond to the entire group. Including the former will call `exec` on each file, and the latter will only call it once.
-- The script parses the `exec` output (:103) to grab the title to show in the notification so multiple calls could break things. I've set it to print `primaryTitle` which should apply to a group of files and limited `awk` to only return the first match, but it's not super bulletproof.
+- If there are multiple media files in a torrent, FileBot will loop through all the files to match and process each. This can also include the `exec` call, depending on the [format expressions](https://www.filebot.net/naming.html) you use (currently set to `{n}`).
+- Some formats (e.g. `{fn}` or episode numbers) correspond to an individual file and some (e.g. `{n}` for movie/series name) correspond to the series or movie. The script will call `exec` on each file when you include the former, and only once per match object when including the latter. A TV season pack is only one match object, but a movie pack will likely have multiple match objects, and multiple `exec` calls.
+- There is a helper (`process-helpers.sh:74`) that parses the `exec` output to grab a nicely formatted name for the notification, but it's not super bulletproof. It's limited to the first matching string to prevent logging/notification errors, but for a pack it might be less accurate.
+
+### Additional files:
+- Some torrents include extras, trailers, subtitles, `.nfo` files, and other related files. FileBot mostly handles these automatically, and you can customize how they're handled by passing additional `--def` options.
+- Sometimes FileBot processes extra files in multiple passes so there might be more than one 'Processed' string. There's a helper (`process-helpers.sh:67`) that should find all these counts and add them up to determine success but this is also a little brittle.
 
 ### Excluded or existing files:
 - FileBot strongly recommends you specify an `excludesList` so it does'nt process things twice. If you're in the testing phase, and FileBot isn't matching when you re-download, check whether your files are on that list and remove them or disable it temporarily.

--- a/README.md
+++ b/README.md
@@ -114,21 +114,22 @@ The script handles most recent, well-named media you might download. There are a
 - I've included a check for the NAS path (`:19`) and if it isn't a directory, call a script that remounts the NAS drive – you can grab that script from my [wifi-keepalive](https://github.com/madysondesigns/wifi-keepalive) repo.
 
 ### Torrent naming conventions:
-- FileBot relies on the name embedded in the torrent metadata (not the `.torrent` filename itself) and uses that to match media. If a torrent is poorly named I assume the results will be less than spectactular, but most torrents I've come across follow good naming conventions so it's not an issue.
-- Older and more obscure media can be more difficult to match – it seems to be more of an issue with TV shows, and I've found that the `tv` label helps (and I assume it can only be good for performance to narrow down the search).
-- I've included some regex logic (`process-helpers.sh:31-:47`) to match common TV naming conventions (e.g. S01E01) but one thing I don't think can be handled automatically is a full series pack – typically these only include the word 'complete' or nothing besides the show name.
+- FileBot relies on the name embedded in the torrent metadata (not the `.torrent` filename itself) and uses that to match media. If a torrent is poorly named I assume the results will be less than spectacular, but most torrents I've come across follow good naming conventions so it's not an issue.
+- Older and more obscure media can be more difficult to match – it seems to be more of an issue with TV shows, and I've found that forcing TV mode with the `tv` label helps (and I assume it can only be good for performance to narrow down the search).
+- I've included some regex logic (`process-helpers.sh:31-:47`) to match common TV naming conventions (e.g. S01E01), and use the `tv` label if so (or use the label provided by Transmission, even though this isn't supported yet).
+- One thing I don't think can be handled automatically is a full series pack – typically these only include the word 'complete' or nothing besides the show name so we have to rely on FileBot completely here.
 
 ### Multi-file torrents:
-- If there are multiple media files in a torrent, FileBot will loop through all the files to match and process each. This can also include the `exec` call, depending on the [format expressions](https://www.filebot.net/naming.html) you use (currently set to `{n}`).
+- If a torrent includes multiple files, FileBot will try to to match and process them as a group and individually. This affects how the `exec` command is called, depending on the [format expressions](https://www.filebot.net/naming.html) you use (currently set to `{n}`).
 - Some formats (e.g. `{fn}` or episode numbers) correspond to an individual file and some (e.g. `{n}` for movie/series name) correspond to the series or movie. The script will call `exec` on each file when you include the former, and only once per match object when including the latter. A TV season pack is only one match object, but a movie pack will likely have multiple match objects, and multiple `exec` calls.
 - There is a helper (`process-helpers.sh:74`) that parses the `exec` output to grab a nicely formatted name for the notification, but it's not super bulletproof. It's limited to the first matching string to prevent logging/notification errors, but for a pack it might be less accurate.
 
 ### Additional files:
-- Some torrents include extras, trailers, subtitles, `.nfo` files, and other related files. FileBot mostly handles these automatically, and you can customize how they're handled by passing additional `--def` options.
-- Sometimes FileBot processes extra files in multiple passes so there might be more than one 'Processed' string. There's a helper (`process-helpers.sh:67`) that should find all these counts and add them up to determine success but this is also a little brittle.
+- Some torrents include extras, trailers, subtitles, `.nfo` files, etc. FileBot mostly handles these automatically, and you can customize how they're handled by passing additional `--def` options.
+- Sometimes FileBot processes extra files in multiple passes so there might be more than one 'Processed' string (no idea why this happens). There's a helper (`process-helpers.sh:67`) that should find all these counts and add them up to determine success but this is also a little brittle.
 
 ### Excluded or existing files:
-- FileBot strongly recommends you specify an `excludesList` so it does'nt process things twice. If you're in the testing phase, and FileBot isn't matching when you re-download, check whether your files are on that list and remove them or disable it temporarily.
+- FileBot strongly recommends you specify an `excludesList` so it doesn't process things twice. If you're in the testing phase, and FileBot isn't matching when you re-download, check whether your files are on that list and remove them or disable it temporarily.
 - FileBot also won't process if the files already exist in the destination folders. There is a `--conflict override` option available, but it hasn't worked for me. If you need to re-download something, delete the existing files before the script runs otherwise FileBot will skip them.
 
 ### Logging:

--- a/process-helpers.sh
+++ b/process-helpers.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+
+# Helpers for Transmission/FileBot processing
+
+# Make logging less repetitve
+print_log () {
+  if [[ -z $LOG_FILE ]]; then
+    print "Script error: \$LOG_FILE not defined" && exit 1
+  else
+    print "[$(date "+%F %T")] $1" | tee -a "$LOG_FILE"
+  fi
+}
+
+# Make downloaded size easier to grok
+convert_size () {
+  local -F gigabytes=$(print -f "%.1f" "$(($1))e-9")
+  local -F megabytes=$(print -f "%.0f" "$(($1))e-6")
+  local LC_ALL=en_US.UTF-8
+
+  [[ $gigabytes -ge 1 ]] && print -f "%'gGB" "$gigabytes" && return
+  [[ $megabytes -ge 1 ]] && print -f "%'.0fMB" "$megabytes" && return
+  print -f "%'gb" "$1" && return
+}
+
+# Check if file matches common TV naming patterns
+probably_tv () {
+  local name=$1
+
+  declare -A newpats
+  newpats["matches 'S00' pattern"]="[S|s][0-9]{1,4}"
+  newpats["includes 'season' string"]="Season|season"
+  newpats["matches 'E00' pattern"]="[E|e]p?[0-9]{1,2}"
+  newpats["matches '0x00' pattern"]="[0-9]{1,2}x[0-9]{1,2}"
+  newpats["includes 'series' string"]="Series|series"
+  newpats["includes 'episode' string"]="Episode|episode"
+
+  for description pattern in ${(kv)newpats}; do
+    [[ "$name" =~ "$pattern" ]] && print "${(Q)description}" && return
+  done
+
+  return 1
+}
+
+# Handle labels if we have them and log results
+# TODO: figure out how to log this
+generate_label () {
+  # local tv_match=$(probably_tv "$1")
+  # local label="N/A"
+
+  # if [[ $TR_TORRENT_LABELS ]]; then
+  #   print_log "Using labels for $1 passed from Transmission"
+  #   label=$TR_TORRENT_LABELS
+  # elif [[ $tv_match ]]; then
+  #   print_log "$1 $tv_match, adding TV label"
+  #   label="tv"
+  # else
+  #   print_log "No labels for $1, allowing FileBot to detect"
+  # fi
+
+  [[ $TR_TORRENT_LABELS ]] && print -f "$TR_TORRENT_LABELS" && return
+  probably_tv "$1" > /dev/null && print -f "tv" && return
+  print -f "N/A" && return
+
+}
+
+# Find the "Processed # files" string and parse the number
+parse_processed () {
+  local processed=$(sed -En "s/^Processed ([0-9]+).*$/\1/p" <<< "$1")
+  local total=$(paste -sd+ - <<< $processed | bc)
+  print -f "$total" && return
+}
+
+# If any files were processed, find the exec output and parse the title
+parse_title () {
+  local title=$(sed -En "s/^Execute: : '(.+)'$/\1/p" <<< "$1" | head -1)
+  print -f "$title" && return
+}

--- a/process-helpers.sh
+++ b/process-helpers.sh
@@ -47,20 +47,18 @@ probably_tv () {
 }
 
 # Handle labels if we have them
-# TODO: figure out how to log this
-generate_label () {
-  # if [[ $TR_TORRENT_LABELS ]]; then
-  #   print_log "Using labels for $1 passed from Transmission"
-  # elif [[ $tv_match ]]; then
-  #   print_log "$1 $tv_match, adding TV label"
-  # else
-  #   print_log "No labels for $1, allowing FileBot to detect"
-  # fi
+update_label () {
+  local tv_match=$(probably_tv "$1")
 
-  [[ $TR_TORRENT_LABELS ]] && print "$TR_TORRENT_LABELS" && return
-  probably_tv "$1" > /dev/null && print "tv" && return
-  print "N/A" && return
-
+  if [[ $TR_TORRENT_LABELS ]]; then
+    LABEL="$TR_TORRENT_LABELS"
+    print_log "Using labels for $1 passed from Transmission"
+  elif [[ $tv_match ]]; then
+    LABEL="tv"
+    print_log "$1 $tv_match, using TV label"
+  else
+    print_log "No labels for $1, allowing FileBot to detect"
+  fi
 }
 
 # Find the "Processed # files" string and parse the number

--- a/process-helpers.sh
+++ b/process-helpers.sh
@@ -11,6 +11,11 @@ print_log () {
   fi
 }
 
+# Notify via Shortcuts
+send_notification () {
+  print "$1" | shortcuts run "Notify All Devices"
+}
+
 # Make downloaded size easier to grok
 convert_size () {
   local -F gigabytes=$(print -f "%.1f" "$(($1))e-9")
@@ -41,25 +46,20 @@ probably_tv () {
   return 1
 }
 
-# Handle labels if we have them and log results
+# Handle labels if we have them
 # TODO: figure out how to log this
 generate_label () {
-  # local tv_match=$(probably_tv "$1")
-  # local label="N/A"
-
   # if [[ $TR_TORRENT_LABELS ]]; then
   #   print_log "Using labels for $1 passed from Transmission"
-  #   label=$TR_TORRENT_LABELS
   # elif [[ $tv_match ]]; then
   #   print_log "$1 $tv_match, adding TV label"
-  #   label="tv"
   # else
   #   print_log "No labels for $1, allowing FileBot to detect"
   # fi
 
-  [[ $TR_TORRENT_LABELS ]] && print -f "$TR_TORRENT_LABELS" && return
-  probably_tv "$1" > /dev/null && print -f "tv" && return
-  print -f "N/A" && return
+  [[ $TR_TORRENT_LABELS ]] && print "$TR_TORRENT_LABELS" && return
+  probably_tv "$1" > /dev/null && print "tv" && return
+  print "N/A" && return
 
 }
 
@@ -67,11 +67,11 @@ generate_label () {
 parse_processed () {
   local processed=$(sed -En "s/^Processed ([0-9]+).*$/\1/p" <<< "$1")
   local total=$(paste -sd+ - <<< $processed | bc)
-  print -f "$total" && return
+  print "$total" && return
 }
 
 # If any files were processed, find the exec output and parse the title
 parse_title () {
   local title=$(sed -En "s/^Execute: : '(.+)'$/\1/p" <<< "$1" | head -1)
-  print -f "$title" && return
+  print "$title" && return
 }

--- a/test-filebot.sh
+++ b/test-filebot.sh
@@ -5,38 +5,49 @@
 # previously downloaded files to tweak FileBot options & formats.
 # Usage: `./test-filebot.sh "path/to/downloaded.torrent"`
 
+SCRIPT_PATH=$(cd "$(dirname "$BASH_SOURCE[0]")" > /dev/null && pwd)
+
+# TODO: make sure real script can get processing path and source path
+source "$SCRIPT_PATH/process-helpers.sh"
+
 # get torrent passed in as an arg and slice off name
 DOWNLOAD_PATH="$1"
 TR_TORRENT_NAME=$(basename "$DOWNLOAD_PATH")
 
 # boilerplate stuff that's auto-generated in the real script
-PLEX_PATH="$( cd "$( dirname "$BASH_SOURCE[0]" )" > /dev/null && pwd )/test"
-LABEL="tv"
+TEST_PATH="$SCRIPT_PATH/test"
+LOG_FILE="$TEST_PATH/$TR_TORRENT_NAME.txt"
 
 # finding things in scrollback sucks
-print "🟢🟢🟢🟢🟢 START TEST for $TR_TORRENT_NAME 🟢🟢🟢🟢🟢"
+print_log "🟢🟢🟢 Testing $TR_TORRENT_NAME 🟢🟢🟢"
+
+# set label
+# TODO: update real script to use helper
+LABEL=$(generate_label "$TR_TORRENT_NAME")
 
 # do the thing, using symlink action because it's faster
 FILEBOT=$(/usr/local/bin/filebot -script fn:amc \
-  --output "$PLEX_PATH" \
+  --output "$TEST_PATH" \
   --action symlink -non-strict \
-  --conflict auto \
+  --conflict override \
   --log-file amc.log \
-  --def unsorted=n music=n artwork=y \
+  --def unsorted=n music=n artwork=n \
     movieDB=TheMovieDB seriesDB=TheMovieDB::TV \
     ut_dir="$DOWNLOAD_PATH" ut_kind="multi" ut_title="$TR_TORRENT_NAME" ut_label="$LABEL" \
-    exec="printf {quote primaryTitle} > /dev/null" \
+    exec=": {quote primaryTitle}" \
   )
-print "$FILEBOT"
+print_log "$FILEBOT"
 
-# find the "Processed # files" string and parse the number
-[[ $FILEBOT ]] && PROCESSED=$(awk '/^Processed/{print $2}' <<< "$FILEBOT")
-print "Processed files: $PROCESSED"
+# check how many files were processed
+# TODO: update real script to use helper
+[[ $FILEBOT ]] && PROCESSED=$(parse_processed $FILEBOT)
+print_log "Processed $PROCESSED files"
 
-if [[ $PROCESSED -ge 1 ]]; then
-  # if any files were processed, find the "Execute: ..." string and parse the title
-  TITLE=$(awk -F"\' | \'" '/^Execute/{print $2; exit}' <<< "$FILEBOT")
-  print "$TITLE processed successfully! 🤖🎉"
+# log results
+if [[ $PROCESSED && $PROCESSED -ge 1 ]]; then
+  # TODO: update real script to use helper
+  TITLE=$(parse_title "$FILEBOT")
+  print_log "🤖🤖🤖 $TITLE processed successfully! 🎉 🤖🤖🤖"
 else
-  print "$TR_TORRENT_NAME not processed 🤖🤷‍♀️"
+  print_log "🤖🤖🤖 $TR_TORRENT_NAME not processed 🤷‍♀️ 🤖🤖🤖"
 fi

--- a/test-filebot.sh
+++ b/test-filebot.sh
@@ -5,9 +5,7 @@
 # previously downloaded files to tweak FileBot options & formats.
 # Usage: `./test-filebot.sh "path/to/downloaded.torrent"`
 
-SCRIPT_PATH=$(cd "$(dirname "$BASH_SOURCE[0]")" > /dev/null && pwd)
-
-# TODO: make sure real script can get processing path and source path
+SCRIPT_PATH=$(dirname $0:A)
 source "$SCRIPT_PATH/process-helpers.sh"
 
 # get torrent passed in as an arg and slice off name
@@ -15,37 +13,34 @@ DOWNLOAD_PATH="$1"
 TR_TORRENT_NAME=$(basename "$DOWNLOAD_PATH")
 
 # boilerplate stuff that's auto-generated in the real script
-TEST_PATH="$SCRIPT_PATH/test"
-LOG_FILE="$TEST_PATH/$TR_TORRENT_NAME.txt"
+OUTPUT_PATH="$SCRIPT_PATH/test"
+LOG_FILE="$OUTPUT_PATH/$TR_TORRENT_NAME.txt"
 
 # finding things in scrollback sucks
 print_log "🟢🟢🟢 Testing $TR_TORRENT_NAME 🟢🟢🟢"
 
 # set label
-# TODO: update real script to use helper
 LABEL=$(generate_label "$TR_TORRENT_NAME")
 
 # do the thing, using symlink action because it's faster
 FILEBOT=$(/usr/local/bin/filebot -script fn:amc \
-  --output "$TEST_PATH" \
+  --output "$OUTPUT_PATH" \
   --action symlink -non-strict \
   --conflict override \
   --log-file amc.log \
   --def unsorted=n music=n artwork=n \
     movieDB=TheMovieDB seriesDB=TheMovieDB::TV \
     ut_dir="$DOWNLOAD_PATH" ut_kind="multi" ut_title="$TR_TORRENT_NAME" ut_label="$LABEL" \
-    exec=": {quote primaryTitle}" \
+    exec=": {quote n}" \
   )
 print_log "$FILEBOT"
 
 # check how many files were processed
-# TODO: update real script to use helper
 [[ $FILEBOT ]] && PROCESSED=$(parse_processed $FILEBOT)
 print_log "Processed $PROCESSED files"
 
 # log results
 if [[ $PROCESSED && $PROCESSED -ge 1 ]]; then
-  # TODO: update real script to use helper
   TITLE=$(parse_title "$FILEBOT")
   print_log "🤖🤖🤖 $TITLE processed successfully! 🎉 🤖🤖🤖"
 else

--- a/test-filebot.sh
+++ b/test-filebot.sh
@@ -3,12 +3,13 @@
 # This script is a simplified version of the main postprocess script that can
 # test FileBot matching directly from the command line. Intended to be run on
 # previously downloaded files to tweak FileBot options & formats.
-# Usage: `./test-filebot.sh "path/to/downloaded.torrent"`
+# Usage: `./test-filebot.sh "path/to/downloaded.files"`
 
+# get working dir and source helpers file
 SCRIPT_PATH=$(dirname $0:A)
 source "$SCRIPT_PATH/process-helpers.sh"
 
-# get torrent passed in as an arg and slice off name
+# get torrent path/name from args
 DOWNLOAD_PATH="$1"
 TR_TORRENT_NAME=$(basename "$DOWNLOAD_PATH")
 
@@ -17,10 +18,11 @@ OUTPUT_PATH="$SCRIPT_PATH/test"
 LOG_FILE="$OUTPUT_PATH/$TR_TORRENT_NAME.txt"
 
 # finding things in scrollback sucks
-print_log "🟢🟢🟢 Testing $TR_TORRENT_NAME 🟢🟢🟢"
+print_log "Testing $TR_TORRENT_NAME 🤖🟢"
 
 # set label
-LABEL=$(generate_label "$TR_TORRENT_NAME")
+LABEL="N/A"
+update_label "$TR_TORRENT_NAME"
 
 # do the thing, using symlink action because it's faster
 FILEBOT=$(/usr/local/bin/filebot -script fn:amc \
@@ -42,7 +44,10 @@ print_log "Processed $PROCESSED files"
 # log results
 if [[ $PROCESSED && $PROCESSED -ge 1 ]]; then
   TITLE=$(parse_title "$FILEBOT")
-  print_log "🤖🤖🤖 $TITLE processed successfully! 🎉 🤖🤖🤖"
+  NOTIFICATION="〝$TITLE〞 processed successfully! 🤖🎉"
 else
-  print_log "🤖🤖🤖 $TR_TORRENT_NAME not processed 🤷‍♀️ 🤖🤖🤖"
+  NOTIFICATION="〝$TR_TORRENT_NAME〞 not processed 🤖🤷‍♀️"
 fi
+
+print_log "$NOTIFICATION"
+send_notification "$NOTIFICATION"

--- a/transmission-postprocess.sh
+++ b/transmission-postprocess.sh
@@ -34,7 +34,8 @@ print_log "Starting postprocess for $TR_TORRENT_NAME..."
 
 # Setup: Handle torrent info
 DOWNLOAD_PATH="$TR_TORRENT_DIR/$TR_TORRENT_NAME"
-LABEL=$(generate_label "$TR_TORRENT_NAME")
+LABEL="N/A"
+update_label "$TR_TORRENT_NAME"
 
 print_log "Processing download: $DOWNLOAD_PATH; label: $LABEL; destination: $PLEX_PATH; size: $(convert_size $TR_TORRENT_BYTES_DOWNLOADED)"
 
@@ -56,9 +57,9 @@ print_log "$FILEBOT"
 [[ $FILEBOT ]] && PROCESSED=$(parse_processed $FILEBOT)
 if [[ $PROCESSED && $PROCESSED -ge 1 ]]; then
   TITLE=$(parse_title "$FILEBOT")
-  NOTIFICATION="$TITLE ready to Plex! 🤖🎉"
+  NOTIFICATION="〝$TITLE〞 ready to Plex! 🤖🎉"
 else
-  NOTIFICATION="$TR_TORRENT_NAME downloaded but not processed 🤖🤷‍♀️"
+  NOTIFICATION="〝$TR_TORRENT_NAME〞 downloaded but not processed 🤖🤷‍♀️"
   cp -r "$DOWNLOAD_PATH" "$PLEX_PATH/Unsorted" && NOTIFICATION+=" (copied to $PLEX_PATH/Unsorted)"
 fi
 


### PR DESCRIPTION
- Move helper functions into a shared file so there's closer parity between testing and the real thing
- Add helpers for string parsing and clean up how this works so it causes fewer logging issues